### PR TITLE
Fix merge bins for corrected matrices

### DIFF
--- a/hicexplorer/HiCMatrix.py
+++ b/hicexplorer/HiCMatrix.py
@@ -37,8 +37,10 @@ class hiCMatrix:
         self.distance_counts = None  # only defined when getCountsByDistance is called
         self.bin_size = None
         self.bin_size_homogeneous = None  # track if the bins are equally spaced or not
-        self.orig_bin_ids = []  # when NaN bins are masked, this variable becomes contains the bin index
-                                # needed to put the masked bins back into the matrix.
+
+        # when NaN bins are masked, this variable becomes contains the bin index
+        # needed to put the masked bins back into the matrix.
+        self.orig_bin_ids = []
         self.orig_cut_intervals = []  # similar to orig_bin_ids. Used to identify the position of masked nan bins
 
         if matrixFile:

--- a/hicexplorer/HiCMatrix.py
+++ b/hicexplorer/HiCMatrix.py
@@ -37,6 +37,9 @@ class hiCMatrix:
         self.distance_counts = None  # only defined when getCountsByDistance is called
         self.bin_size = None
         self.bin_size_homogeneous = None  # track if the bins are equally spaced or not
+        self.orig_bin_ids = []  # when NaN bins are masked, this variable becomes contains the bin index
+                                # needed to put the masked bins back into the matrix.
+        self.orig_cut_intervals = []  # similar to orig_bin_ids. Used to identify the position of masked nan bins
 
         if matrixFile:
             self.nan_bins = np.array([])
@@ -1334,18 +1337,15 @@ class hiCMatrix:
             return
 
         self.printchrtoremove(bin_ids, restore_masked_bins=False)
-        try:
-            # check if a masked bin already exists
-            if len(self.orig_bin_ids) > 0:
-                print "Masked bins already present"
-                M = self.matrix.shape[0]
-                previous_bin_ids = self.orig_bin_ids[M:]
-                # merge new and old masked bins
-                bin_ids = np.unique(np.concatenate([previous_bin_ids, self.orig_bin_ids[bin_ids]]))
-                np.sort(bin_ids)
-                self.restoreMaskedBins()
-        except:
-            pass
+        # check if a masked bin already exists
+        if len(self.orig_bin_ids) > 0:
+            print "Masked bins already present"
+            M = self.matrix.shape[0]
+            previous_bin_ids = self.orig_bin_ids[M:]
+            # merge new and old masked bins
+            bin_ids = np.unique(np.concatenate([previous_bin_ids, self.orig_bin_ids[bin_ids]]))
+            np.sort(bin_ids)
+            self.restoreMaskedBins()
 
         # join with existing nan_bins
         if len(self.nan_bins) > 0:
@@ -1364,13 +1364,11 @@ class hiCMatrix:
 
         new_cut_intervals = [self.cut_intervals[x] for x in rows]
 
-        self.orig_cut_intervals = \
-            new_cut_intervals + [self.cut_intervals[x] for x in bin_ids]
+        self.orig_cut_intervals = new_cut_intervals + [self.cut_intervals[x] for x in bin_ids]
 
         self.cut_intervals = new_cut_intervals
 #        self.nan_bins = np.intersect1d(self.nan_bins, rows)
-        self.interval_trees, self.chrBinBoundaries = \
-            self.intervalListToIntervalTree(self.cut_intervals)
+        self.interval_trees, self.chrBinBoundaries = self.intervalListToIntervalTree(self.cut_intervals)
 
         if self.correction_factors is not None:
             self.correction_factors = self.correction_factors[rows]
@@ -1384,7 +1382,7 @@ class hiCMatrix:
         (chrom, start, end, coverage)
         :return:
         """
-        if hasattr(self, 'orig_bin_ids'):
+        if len(self.orig_bin_ids) > 0:
             raise Exception("matrix contains masked bins. Restore masked bins first")
 
         assert len(new_cut_intervals) == new_matrix.shape[0], "matrix shape and len of cut intervals do not match"
@@ -1401,10 +1399,49 @@ class hiCMatrix:
         """
         Puts backs into the matrix the bins
         removed
+
+
+        Examples
+        --------
+        >>> from scipy.sparse import coo_matrix
+        >>> row, col = np.triu_indices(5)
+        >>> cut_intervals = [('a', 0, 10, 1), ('a', 10, 20, 1),
+        ... ('a', 20, 30, 1), ('a', 30, 40, 1), ('b', 40, 50, 1)]
+        >>> hic = hiCMatrix()
+        >>> hic.nan_bins = []
+        >>> matrix = np.array([
+        ... [ 0, 10,  5, 3, 0],
+        ... [ 0,  0, 15, 5, 1],
+        ... [ 0,  0,  0, 7, 3],
+        ... [ 0,  0,  0, 0, 1],
+        ... [ 0,  0,  0, 0, 0]])
+
+        make the matrix symmetric:
+        >>> hic.matrix = csr_matrix(matrix + matrix.T)
+        >>> hic.setMatrix(csr_matrix(matrix + matrix.T), cut_intervals)
+
+        Add masked bins masked bins
+        >>> hic.maskBins([3])
+        >>> hic.matrix.todense()
+        matrix([[ 0, 10,  5,  0],
+                [10,  0, 15,  1],
+                [ 5, 15,  0,  3],
+                [ 0,  1,  3,  0]])
+        >>> hic.cut_intervals
+        [('a', 0, 10, 1), ('a', 10, 20, 1), ('a', 20, 30, 1), ('b', 40, 50, 1)]
+
+        >>> hic.restoreMaskedBins()
+        >>> hic.matrix.todense()
+        matrix([[  0.,  10.,   5.,   0.,   0.],
+                [ 10.,   0.,  15.,   0.,   1.],
+                [  5.,  15.,   0.,   0.,   3.],
+                [  0.,   0.,   0.,   0.,   0.],
+                [  0.,   1.,   3.,   0.,   0.]])
+
+        >>> hic.cut_intervals
+        [('a', 0, 10, 1), ('a', 10, 20, 1), ('a', 20, 30, 1), ('a', 30, 40, 1), ('b', 40, 50, 1)]
         """
-        try:
-            self.orig_bin_ids
-        except AttributeError:
+        if len(self.orig_bin_ids) == 0:
             return
         # the rows to add are
         # as an empty sparse matrix
@@ -1435,7 +1472,10 @@ class hiCMatrix:
                                                       np.repeat(np.nan, N)])
             # reorder array
             self.correction_factors = self.correction_factors[rows]
-        del(self.orig_cut_intervals, self.orig_bin_ids)
+
+        # reset orig bins ids and cut intervals
+        self.orig_bin_ids = []
+        self.orig_cut_intervals = []
         sys.stderr.write("masked bins were restored\n")
 
     def reorderMatrix(self, orig, dest):
@@ -1551,13 +1591,10 @@ class hiCMatrix:
             return
 
         if restore_masked_bins:
-            try:
-                # check if a masked bin already exists
-                if len(self.orig_bin_ids) > 0:
-                    print "Masked bins already present"
-                    self.restoreMaskedBins()
-            except:
-                pass
+            # check if a masked bin already exists
+            if len(self.orig_bin_ids) > 0:
+                print "Masked bins already present"
+                self.restoreMaskedBins()
         for idx in to_remove:
             chrom = self.cut_intervals[idx][0]
             if chrom not in cnt:

--- a/hicexplorer/hicMergeMatrixBins.py
+++ b/hicexplorer/hicMergeMatrixBins.py
@@ -232,6 +232,22 @@ def main():
 
     args = parse_arguments().parse_args()
     hic = hm.hiCMatrix(args.matrix)
+    if len(hic.nan_bins):
+        # Usually, only corrected matrices contain NaN bins.
+        # this need to be removed before merging the bins.
+        hic.maskBins(hic.nan_bins)
+
+        # NaN bins are problematic when merging bins because they
+        # become non consecutive. Ideally, is better to merge bins on
+        # uncorrected matrices and correct again.
+
+        # Remove the information about NaN bins because they can not be merged
+        hic.orig_bin_ids = []
+        hic.orig_cut_intervals = []
+
+        sys.stderr.write("*WARNING*: The matrix is probably a corrected matrix that contains NaN bins. This bins "
+                         "can not be merged and are removed. It is preferable to first merge bins in a uncorrected  "
+                         "matrix and then correct the matrix.\n")
     if args.runningWindow:
         merged_matrix = running_window_merge(hic, args.numBins)
     else:

--- a/hicexplorer/hicMergeMatrixBins.py
+++ b/hicexplorer/hicMergeMatrixBins.py
@@ -46,6 +46,28 @@ def parse_arguments(args=None):
     return parser
 
 
+def remove_nans_if_needed(hic):
+    if len(hic.nan_bins):
+        # Usually, only corrected matrices contain NaN bins.
+        # this need to be removed before merging the bins.
+        hic.maskBins(hic.nan_bins)
+
+        # NaN bins are problematic when merging bins because they
+        # become non consecutive. Ideally, is better to merge bins on
+        # uncorrected matrices and correct again.
+
+        # Remove the information about NaN bins because they can not be merged
+        hic.orig_bin_ids = []
+        hic.orig_cut_intervals = []
+        hic.correction_factors = None
+
+        sys.stderr.write("*WARNING*: The matrix is probably a corrected matrix that contains NaN bins. This bins "
+                         "can not be merged and are removed. It is preferable to first merge bins in a uncorrected  "
+                         "matrix and then correct the matrix. Correction factors, if present, are removed as well.\n")
+
+    return hic
+
+
 def running_window_merge(hic_matrix, num_bins):
     """Creates a 'running window' merge without changing the
     original resolution of the matrix. The window size is
@@ -98,6 +120,7 @@ def running_window_merge(hic_matrix, num_bins):
             [4, 6, 5, 3]])
     """
 
+    hic_matrix = remove_nans_if_needed(hic_matrix)
     if num_bins == 1:
         return hic_matrix
 
@@ -142,6 +165,7 @@ def running_window_merge(hic_matrix, num_bins):
 
     hic_matrix.matrix = new_ma
     hic_matrix.nan_bins = np.flatnonzero(hic_matrix.matrix.sum(0).A == 0)
+    hic_matrix.matrix.eliminate_zeros()
 
     return hic_matrix
 
@@ -193,6 +217,8 @@ def merge_bins(hic, num_bins):
             [ 28, 177,   4],
             [  1,   4, 100]])
     """
+
+    hic = remove_nans_if_needed(hic)
     # get the bins to merge
     ref_name_list, start_list, end_list, coverage_list = zip(*hic.cut_intervals)
     new_bins = []
@@ -222,6 +248,7 @@ def merge_bins(hic, num_bins):
     bins_to_merge.append(range(idx_start, idx + 1))
 
     hic.matrix = reduce_matrix(hic.matrix, bins_to_merge, diagonal=True)
+    hic.matrix.eliminate_zeros()
     hic.cut_intervals = new_bins
     hic.nan_bins = np.flatnonzero(hic.matrix.sum(0).A == 0)
 
@@ -232,38 +259,10 @@ def main():
 
     args = parse_arguments().parse_args()
     hic = hm.hiCMatrix(args.matrix)
-    if len(hic.nan_bins):
-        # Usually, only corrected matrices contain NaN bins.
-        # this need to be removed before merging the bins.
-        hic.maskBins(hic.nan_bins)
 
-        # NaN bins are problematic when merging bins because they
-        # become non consecutive. Ideally, is better to merge bins on
-        # uncorrected matrices and correct again.
-
-        # Remove the information about NaN bins because they can not be merged
-        hic.orig_bin_ids = []
-        hic.orig_cut_intervals = []
-
-        sys.stderr.write("*WARNING*: The matrix is probably a corrected matrix that contains NaN bins. This bins "
-                         "can not be merged and are removed. It is preferable to first merge bins in a uncorrected  "
-                         "matrix and then correct the matrix.\n")
     if args.runningWindow:
         merged_matrix = running_window_merge(hic, args.numBins)
     else:
         merged_matrix = merge_bins(hic, args.numBins)
-
-    print 'saving matrix'
-    # there is a pickle problem with large arrays
-    # To increase the sparsity of the matrix and
-    # overcome the problem
-    # I transform al ones into zeros.
-    """
-    merged_matrix.matrix.data = merged_matrix.matrix.data - 1
-    """
-    merged_matrix.matrix.eliminate_zeros()
-    if merged_matrix.correction_factors is not None:
-        sys.stderr.write("*WARNING*: The corrections factors are not merged and are set to None\n")
-        merged_matrix.correction_factors = None
 
     merged_matrix.save(args.outFileName)


### PR DESCRIPTION
The code for hicMergeMatrixBins erroneously merged nan bins. This was problematic only when merging bins from corrected matrices.