### PR TITLE
Recover possible valid dangling ends

### DIFF
--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -1378,8 +1378,7 @@ Max library insert size\t{}\t\t
                    format(mate_not_close_to_rf, 100 * float(mate_not_close_to_rf) / mappable_unique_high_quality_pairs))
 
     log_file.write("same fragment\t{}\t({:.2f})\n".
-                   format(args.maxLibraryInsertSize,
-                          same_fragment, 100 * float(same_fragment) / mappable_unique_high_quality_pairs))
+                   format(same_fragment, 100 * float(same_fragment) / mappable_unique_high_quality_pairs))
 
     log_file.write("self circle\t{}\t({:.2f})\n".
                    format(self_circle, 100 * float(self_circle) / mappable_unique_high_quality_pairs))

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -135,6 +135,10 @@ def parse_arguments(args=None):
                         default=300,
                         required=False)
 
+    parser.add_argument('--maxDistance',
+                        help='This parameter is now obsolete. Use --maxLibraryInsertSize instead',
+                        type=int)
+
     parser.add_argument('--maxLibraryInsertSize',
                         help='The maximum library insert size defines different cut offs based on the maximum expected '
                              'library size. *This is not the average fragment size* but the higher end of the '
@@ -988,6 +992,10 @@ def main(args=None):
     """
 
     args = parse_arguments().parse_args(args)
+
+    # for backwards compatibility
+    if args.maxDistance is not None:
+        args.maxLibraryInsertSize = args.maxDistance
     try:
         QC.make_sure_path_exists(args.QCfolder)
     except OSError:

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -135,12 +135,15 @@ def parse_arguments(args=None):
                         default=300,
                         required=False)
 
-    parser.add_argument('--maxDistance',
-                        help='Maximum distance (in bp) from restriction site '
-                        'to read, to consider a read a valid one. This option '
-                        'only applies if --restrictionCutFile is given.',
+    parser.add_argument('--maxLibraryInsertSize',
+                        help='The maximum library insert size defines different cut offs based on the maximum expected '
+                             'library size. *This is not the average fragment size* but the higher end of the '
+                             'which usually is between 800 to 1500 bp. If this value if not known use the default of '
+                             '1000. The insert value is used to decide if a two mates belong to the same fragment (by '
+                             'checking if they are within this max insert size) and to decide if a mate is too far '
+                             'away from the nearest restriction site.',
                         type=int,
-                        default=800,
+                        default=1000,
                         required=False)
 
     parser.add_argument('--restrictionSequence', '-seq',
@@ -684,7 +687,8 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
                  pDanglingSequences, pBinsize, pResultIndex,
                  pQueueOut, pTemplate, pOutputBamSet, pCounter,
                  pSharedBinIntvalTree, pDictBinIntervalTreeIndex, pCoverage, pCoverageIndex,
-                 pOutputFileBufferDir, pRow, pCol, pData):
+                 pOutputFileBufferDir, pRow, pCol, pData,
+                 pMaxInsertSize):
     """
     This function computes for a given number of elements in pMateBuffer1 and pMaterBuffer2 a partial interaction matrix.
     This function is used by multiple processes to speed up the computation.
@@ -720,7 +724,8 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
     pOutputFileBufferDir : String, the directory where the partial output bam files are buffered. Default is '/dev/shm/'
     pRow : multiprocessing.sharedctype.RawArray of c_uint, Stores the row index information. It is available for all processes and does not need to be copied.
     pCol : multiprocessing.sharedctype.RawArray of c_uint, stores the column index information. It is available for all processes and does not need to be copied.
-    pDat : multiprocessing.sharedctype.RawArray of c_ushort, stores a 1 for each row - column pair. It is available for all processes and does not need to be copied.
+    pData : multiprocessing.sharedctype.RawArray of c_ushort, stores a 1 for each row - column pair. It is available for all processes and does not need to be copied.
+    pMaxInsertSize : maximum illumina insert size
     """
 
     one_mate_unmapped = 0
@@ -803,7 +808,7 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
             mate_bins.append(mate_bin_id)
 
         # if a mate is unassigned, it means it is not close
-        # to a restriction sites
+        # to a restriction site
         if mate_is_unasigned is True:
             mate_not_close_to_rf += 1
             continue
@@ -870,16 +875,16 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
                         if not pKeepSelfCircles:
                             continue
 
-            # check for dangling ends if the restriction sequence
-            # is known:
-            if pRestrictionSequence:
-                if pDanglingSequences:
-                    if check_dangling_end(mate1, pDanglingSequences) or \
-                            check_dangling_end(mate2, pDanglingSequences):
-                        dangling_end += 1
-                        continue
 
-            if abs(mate2.pos - mate1.pos) < 1000 and orientation == 'inward':
+            if abs(mate2.pos - mate1.pos) < pMaxInsertSize and orientation == 'inward':
+                # check for dangling ends if the restriction sequence is known and if they look
+                # like 'same fragment'
+                if pRestrictionSequence:
+                    if pDanglingSequences:
+                        if check_dangling_end(mate1, pDanglingSequences) or \
+                                check_dangling_end(mate2, pDanglingSequences):
+                            dangling_end += 1
+                            continue
                 has_rf = []
 
                 if pRfPositions and pRestrictionSequence:
@@ -1017,7 +1022,7 @@ def main(args=None):
         rf_interval = bed2interval_list(args.restrictionCutFile)
         bin_intervals = get_rf_bins(rf_interval,
                                     min_distance=args.minDistance,
-                                    max_distance=args.maxDistance)
+                                    max_distance=args.maxLibraryInsertSize)
 
         rf_positions = intervalListToIntervalTree(rf_interval)
     else:
@@ -1176,7 +1181,8 @@ def main(args=None):
                     pOutputFileBufferDir="",
                     pRow=row[i],
                     pCol=col[i],
-                    pData=data[i]
+                    pData=data[i],
+                    pMaxInsertSize=args.maxLibraryInsertSize
                 ))
                 process[i].start()
                 count_output += 1
@@ -1331,10 +1337,9 @@ def main(args=None):
 File\t{}\t\t
 Pairs considered\t{}\t\t
 Min rest. site distance\t{}\t\t
-Max rest. site distance\t{}\t\t
+Max library insert size\t{}\t\t
 
-""".format(args.outFileName.name, iter_num, args.minDistance,
-           args.maxDistance))
+""".format(args.outFileName.name, iter_num, args.minDistance, args.maxLibraryInsertSize))
 
     log_file.write("#\tcount\t(percentage w.r.t. total sequenced reads)\n")
 
@@ -1365,8 +1370,9 @@ Max rest. site distance\t{}\t\t
     log_file.write("One mate not close to rest site\t{}\t({:.2f})\n".
                    format(mate_not_close_to_rf, 100 * float(mate_not_close_to_rf) / mappable_unique_high_quality_pairs))
 
-    log_file.write("same fragment (800 bp)\t{}\t({:.2f})\n".
-                   format(same_fragment, 100 * float(same_fragment) / mappable_unique_high_quality_pairs))
+    log_file.write("same fragment)\t{}\t({:.2f})\n".
+                   format(args.maxLibraryInsertSize,
+                          same_fragment, 100 * float(same_fragment) / mappable_unique_high_quality_pairs))
 
     log_file.write("self circle\t{}\t({:.2f})\n".
                    format(self_circle, 100 * float(self_circle) / mappable_unique_high_quality_pairs))

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -879,7 +879,6 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
                         if not pKeepSelfCircles:
                             continue
 
-
             if abs(mate2.pos - mate1.pos) < pMaxInsertSize and orientation == 'inward':
                 # check for dangling ends if the restriction sequence is known and if they look
                 # like 'same fragment'

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -1378,7 +1378,7 @@ Max library insert size\t{}\t\t
     log_file.write("One mate not close to rest site\t{}\t({:.2f})\n".
                    format(mate_not_close_to_rf, 100 * float(mate_not_close_to_rf) / mappable_unique_high_quality_pairs))
 
-    log_file.write("same fragment)\t{}\t({:.2f})\n".
+    log_file.write("same fragment\t{}\t({:.2f})\n".
                    format(args.maxLibraryInsertSize,
                           same_fragment, 100 * float(same_fragment) / mappable_unique_high_quality_pairs))
 

--- a/hicexplorer/hicPrepareQCreport.py
+++ b/hicexplorer/hicPrepareQCreport.py
@@ -62,7 +62,7 @@ def save_html(filename, unmap_table, discard_table, distance_table, orientation_
 
     all_table = all_table[['Pairs considered', 'Pairs mappable, unique and high quality', 'Pairs used',
                            'One mate unmapped', 'One mate not unique', 'One mate low quality', 'dangling end',
-                           'self ligation (removed)', 'One mate not close to rest site', 'same fragment (800 bp)',
+                           'self ligation (removed)', 'One mate not close to rest site', 'same fragment',
                            'self circle', 'duplicated pairs', 'inter chromosomal', 'short range < 20kb',
                            'long range', 'inward pairs', 'outward pairs', 'left pairs', 'right pairs']]
 
@@ -118,7 +118,7 @@ def make_figure_umappable_non_unique_reads(table, filename, dpi):
 
 def make_figure_pairs_discarded(table, filename, dpi):
     prc_table = table[['One mate not close to rest site', 'dangling end', 'duplicated pairs',
-                       'same fragment (800 bp)', 'self circle',
+                       'same fragment', 'self circle',
                        'self ligation (removed)']].T / table['Pairs mappable, unique and high quality']
 
     fig = plt.figure(figsize=(7, 5))
@@ -133,12 +133,12 @@ def make_figure_pairs_discarded(table, filename, dpi):
 
     # merge the counts table with the percentages table
     ret_table = table[['One mate not close to rest site', 'dangling end', 'duplicated pairs',
-                       'same fragment (800 bp)', 'self circle',
+                       'same fragment', 'self circle',
                        'self ligation (removed)']].join(prc_table.T, rsuffix=' %')
 
     return ret_table[['One mate not close to rest site', 'One mate not close to rest site %',
                       'dangling end', 'dangling end %', 'duplicated pairs', 'duplicated pairs %',
-                      'same fragment (800 bp)', 'same fragment (800 bp) %',
+                      'same fragment', 'same fragment %',
                       'self circle', 'self circle %', 'self ligation (removed)', 'self ligation (removed) %']]
 
 
@@ -203,7 +203,7 @@ def main(args=None):
     dangling end    209     (0.40)
     self ligation (removed) 5056    (9.59)
     One mate not close to rest site 751     (1.42)
-    same fragment (800 bp)  10146   (19.24)
+    same fragment  10146   (19.24)
     self circle     4274    (8.11)
     duplicated pairs        12      (0.02)
 
@@ -256,6 +256,10 @@ def main(args=None):
         table['Pairs mappable, unique and high quality'] = \
             table['Pairs considered'] - (table['One mate unmapped'] + table['One mate not unique'] +
                                          table['One mate low quality'])
+
+    if 'same fragment (800 bp)' in table.columns:
+        # older versions of the QC used the label 'same fragment (800 bp)'
+        table['same fragment'] = table['same fragment (800 bp)']
 
     make_figure_pairs_used(table, args.outputFolder + "/pairs_sequenced.png", args.dpi)
     unmap_table = make_figure_umappable_non_unique_reads(table, args.outputFolder + "/unmappable_and_non_unique.png",

--- a/hicexplorer/test/test_buildMatrix.py
+++ b/hicexplorer/test/test_buildMatrix.py
@@ -55,9 +55,9 @@ def test_build_matrix_rf():
            "--restrictionSequence GATC " \
            "--danglingSequence GATC " \
            "--minDistance 150 " \
-           "--maxDistance 1500 --threads 4".format(sam_R1, sam_R2, dpnii_file,
-                                                   outfile.name,
-                                                   qc_folder).split()
+           "--maxLibraryInsertSize 1500 --threads 4".format(sam_R1, sam_R2, dpnii_file,
+                                                            outfile.name,
+                                                            qc_folder).split()
     hicBuildMatrix.main(args)
 
     test = hm.hiCMatrix(ROOT + "small_test_rf_matrix.h5")


### PR DESCRIPTION
The previous dangling end didn't consider the possibility that reads that end on the restriction site could be valid Hi-C pairs. This PR fixes that. 