### PR TITLE
fixed new z-score and obs/exp --transform options

### DIFF
--- a/bin/hicAggregateContacts
+++ b/bin/hicAggregateContacts
@@ -112,12 +112,12 @@ def main(args):
 
     if args.transform == "z-score":
         # use zscore matrix
-        log.info("Computing z-score matrix. This may take a while.\n")
-        ma.convert_to_zscore_matrix(maxdepth=max_dist * 2.5, perchr=True)
+#        log.info("Computing z-score matrix. This may take a while.\n")
+        ma.convert_to_zscore_matrix(float(max_dist) * 2.5, perchr=True)
     elif args.transform == "obs/exp":
         # use zscore matrix
-        log.info("Computing observed vs. expected matrix. This may take a while.\n")
-        ma.convert_to_obs_exp_matrix(maxdepth=max_dist * 2.5, perchr=True)
+#        log.info("Computing observed vs. expected matrix. This may take a while.\n")
+        ma.convert_to_obs_exp_matrix(float(max_dist) * 2.5, perchr=True)
 
     # read and sort bedgraph. 
     bed_intervals = read_bed_per_chrom(args.BED)


### PR DESCRIPTION
log.file lines throw `NameError: global name 'log' is not defined (lines 115 and 119)`

New transformation lines throwed:
```
   ma.convert_to_zscore_matrix(maxdepth=max_dist * 2.5, perchr=True)
TypeError: can't multiply sequence by non-int of type 'float'
```

* [ ] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

