### PR TITLE
New option --outFilePrefixMatrix for hicAggregateContacts

### DIFF
--- a/bin/hicAggregateContacts
+++ b/bin/hicAggregateContacts
@@ -59,9 +59,9 @@ def parseArguments(args=None):
                         type=argparse.FileType('w'),
                         required=True)
     
-    parser.add_argument('--outFileNameMatrix',
-                        help='If this option is given, then the values underlying the final matrix will be saved to a'
-                        'tab-delimited table using the indicated name.'
+    parser.add_argument('--outFilePrefixMatrix',
+                        help='If this option is given, then the values underlying the final matrix will be saved to '
+                        'tab-delimited tables (one per chromosome) using the indicated prefix, for example TSS_to_TSS_chrX.tab'
                         type=argparse.FileType('w'),
                         required=False)
 
@@ -288,14 +288,15 @@ def main(args):
             ax.set_zticklabels([])
             if vmax is not None and vmax is not None:
                 ax.set_zlim(vmin, vmax)
-
+                
+        if args.outFilePrefixMatrix:
+            output_matrix_name=("".join((args.outFilePrefixMatrix.name, "_", chrom, ".tab")))
+            np.savetxt(output_matrix_name, chrom_matrix[chrom], '%0.5f', delimiter='\t')
+            
     cbar_x = plt.subplot(gs[-1])
     fig.colorbar(img, cax=cbar_x)
     plt.savefig(args.outFileName.name, dpi=100, transparent=True)
     plt.close()
-
-    if args.outFileNameMatrix:
-        np.savetxt(args.outFileNameMatrix.name, chrom_matrix[chrom], '%0.5f', delimiter='\t')
     
     # plot the diagonals
     # the diagonals plot is useful to see individual cases and if they had a contact in the center

--- a/bin/hicAggregateContacts
+++ b/bin/hicAggregateContacts
@@ -290,7 +290,7 @@ def main(args):
                 ax.set_zlim(vmin, vmax)
                 
         if args.outFilePrefixMatrix:
-            output_matrix_name=("".join((args.outFilePrefixMatrix.name, "_", chrom, ".tab")))
+            output_matrix_name="{file}_{chrom}.tab".format(file=args.outFilePrefixMatrix.name, chrom=chrom)
             np.savetxt(output_matrix_name, chrom_matrix[chrom], '%0.5f', delimiter='\t')
             
     cbar_x = plt.subplot(gs[-1])

--- a/bin/hicAggregateContacts
+++ b/bin/hicAggregateContacts
@@ -21,11 +21,11 @@ def parseArguments(args=None):
 
     # define the arguments
     parser.add_argument('--matrix', '-m',
-                        help='path of the Hi-C matrix to plot',
+                        help='path of the Hi-C matrix to plot.',
                         required=True)
 
     parser.add_argument('--BED',
-                        help='BED file with regions to plot interactions',
+                        help='BED file with regions to plot interactions.',
                         type=argparse.FileType('r'),
                         required=True)
 
@@ -50,7 +50,7 @@ def parseArguments(args=None):
                         default='none')
 
     parser.add_argument('--avgType',
-                        help='type of average to compute final matrix. Options are mean and median. Default is median',
+                        help='type of average to compute final matrix. Options are mean and median. Default is median.',
                         choices=['mean', 'median'],
                         default='median')
 
@@ -58,6 +58,12 @@ def parseArguments(args=None):
                         help='File name to save the image. ',
                         type=argparse.FileType('w'),
                         required=True)
+    
+    parser.add_argument('--outFileNameMatrix',
+                        help='If this option is given, then the values underlying the final matrix will be saved to a'
+                        'tab-delimited table using the indicated name.'
+                        type=argparse.FileType('w'),
+                        required=False)
 
     parser.add_argument('--diagnosticHeatmapFile',
                         help='If given, a heatmap file (per chromosome) is saved. Each row in the heatmap contains the'
@@ -288,6 +294,9 @@ def main(args):
     plt.savefig(args.outFileName.name, dpi=100, transparent=True)
     plt.close()
 
+    if args.outFileNameMatrix:
+        np.savetxt(args.outFileNameMatrix.name, chrom_matrix[chrom], '%0.5f', delimiter='\t')
+    
     # plot the diagonals
     # the diagonals plot is useful to see individual cases and if they had a contact in the center
     if args.diagnosticHeatmapFile:


### PR DESCRIPTION
Output final matrix values to a tab-delimited table if the option is given followed by the name of the file.

* [ ] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

