### PR TITLE
Revert "Proceed correctly if HicFindTads.peakdetect returned an empty list of local minima"

### DIFF
--- a/hicexplorer/hicFindTADs.py
+++ b/hicexplorer/hicFindTADs.py
@@ -605,10 +605,7 @@ class HicFindTads(object):
 
         # compute local minima for the matrix average
         _max, _min = HicFindTads.peakdetect(tad_score_matrix_avg, lookahead=lookahead, chrom=chrom)
-        if _min:
-            min_idx, _ = zip(*_min)
-        else:
-            min_idx = []
+        min_idx, value = zip(*_min)
 
         # get the delta for each boundary
         delta_to_mean = HicFindTads.delta_wrt_window(min_idx, tad_score_matrix_avg, chrom)


### PR DESCRIPTION
Reverts deeptools/HiCExplorer#190

I revert this merge because the required test cases were not added.