### PR TITLE
fix problem when plotting a bigwig track when chromosome length short

### DIFF
--- a/hicexplorer/hicPlotMatrix.py
+++ b/hicexplorer/hicPlotMatrix.py
@@ -756,6 +756,3 @@ def plotBigwig(pAxis, pNameOfBigwigList, pChromosomeSizes=None, pRegion=None, pX
 
     if x_values is not None and bigwig_scores is not None:
         pAxis.fill_between(x_values, 0, bigwig_scores, edgecolor='none')
-
-
-    # pAxis.get_xaxis().set_visible(False)


### PR DESCRIPTION
This solves an issue with chromosome (usually scaffolds/contigs) whose length is less than 100kb

* [x] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [x] Local tests pass (`py.test hicexplorer --doctest-modules`)

