### PR TITLE
fix toString for numpy arrays

### DIFF
--- a/hicexplorer/HiCMatrix.py
+++ b/hicexplorer/HiCMatrix.py
@@ -199,7 +199,7 @@ class hiCMatrix:
         cut_intervals = []
 
         for values in cut_intervals_data_frame.values:
-            cut_intervals.append(tuple([toBytes(values[0]), values[1], values[2], 1.0]))
+            cut_intervals.append(tuple([toString(values[0]), values[1], values[2], 1.0]))
 
         # try to restore nan_bins.
         try:
@@ -284,8 +284,7 @@ class hiCMatrix:
         else:
             distance_counts = _ma['dist_counts'].tolist()
 
-        map(toString, _ma['chrNameList'])
-        cut_intervals = zip(_ma['chrNameList'], _ma['startList'],
+        cut_intervals = zip(toString(_ma['chrNameList']), _ma['startList'],
                             _ma['endList'], _ma['extraList'])
 
         assert len(cut_intervals) == matrix.shape[0], \
@@ -880,13 +879,13 @@ class hiCMatrix:
                 # if zscore is needed, compute standard deviation: std = sqrt(mean(abs(x - x.mean())**2))
                 if zscore:
                     values_sqrt_diff = \
-                        np.abs((submatrix.data[dist_list == bin_dist_plus_one] - mu[bin_dist_plus_one])**2)
+                        np.abs((submatrix.data[dist_list == bin_dist_plus_one] - mu[bin_dist_plus_one]) ** 2)
                     # the standard deviation is the sum of the differences with mu squared (value variable)
                     # plus all zeros that are not included in the sparse matrix
                     # for which the standard deviation is
                     # (0 - mu)**2 = (mu)**2
                     # The number of zeros is the diagonal length - the length of the non zero values
-                    zero_values_sqrt_diff_sum = (diagonal_length - len(values_sqrt_diff)) * mu[bin_dist_plus_one]**2
+                    zero_values_sqrt_diff_sum = (diagonal_length - len(values_sqrt_diff)) * mu[bin_dist_plus_one] ** 2
 
                     _std = np.sqrt((values_sqrt_diff.sum() + zero_values_sqrt_diff_sum) / diagonal_length)
                     std[bin_dist_plus_one] = _std

--- a/hicexplorer/hicAggregateContacts.py
+++ b/hicexplorer/hicAggregateContacts.py
@@ -12,7 +12,7 @@ import matplotlib.gridspec as gridspec
 import matplotlib.cm as cm
 import hicexplorer.HiCMatrix as hm
 import hicexplorer.utilities
-from .utilities import toBytes
+from .utilities import toString
 from .utilities import check_chrom_str_bytes
 
 import logging
@@ -557,7 +557,7 @@ def main(args=None):
         seen[chrom] = set()
         over_1_5 = 0
         empty_mat = 0
-        chrom_bin_range = ma.getChrBinRange(toBytes(chrom))
+        chrom_bin_range = ma.getChrBinRange(toString(chrom))
 
         log.info("processing {}".format(chrom))
 
@@ -566,7 +566,7 @@ def main(args=None):
             # check all other regions that may interact with the
             # current interval at the given depth range
 
-            bin_id = ma.getRegionBinRange(toBytes(chrom), start, end)
+            bin_id = ma.getRegionBinRange(toString(chrom), start, end)
             if bin_id is None:
                 continue
             else:
@@ -577,7 +577,7 @@ def main(args=None):
                 if counter % 50000 == 0:
                     log.info("Number of contacts considered: {:,}".format(counter))
 
-                bin_id2 = ma.getRegionBinRange(toBytes(chrom), start2, end2)
+                bin_id2 = ma.getRegionBinRange(toString(chrom), start2, end2)
                 if bin_id2 is None:
                     continue
                 else:

--- a/hicexplorer/hicPlotMatrix.py
+++ b/hicexplorer/hicPlotMatrix.py
@@ -499,7 +499,7 @@ def main(args=None):
             log.debug("ma.chrBinBoundaries {}".format(ma.chrBinBoundaries))
             if sys.version_info[0] == 3:
                 args.chromosomeOrder = toBytes(args.chromosomeOrder)
-            for chrom in args.chromosomeOrder:
+            for chrom in toString(args.chromosomeOrder):
                 if chrom in ma.chrBinBoundaries:
                     valid_chromosomes.append(chrom)
                 else:

--- a/hicexplorer/test/test_hicmatrix.py
+++ b/hicexplorer/test/test_hicmatrix.py
@@ -21,8 +21,8 @@ ROOT = os.path.dirname(os.path.abspath(__file__)) + "/test_data/"
 
 def test_save_load():
     outfile = '/tmp/matrix.h5'
-    cut_intervals = [(b'a', 0, 10, 1), (b'a', 10, 20, 1),
-                     (b'a', 20, 30, 1), (b'a', 30, 40, 1), (b'b', 40, 50, 1)]
+    cut_intervals = [('a', 0, 10, 1), ('a', 10, 20, 1),
+                     ('a', 20, 30, 1), ('a', 30, 40, 1), ('b', 40, 50, 1)]
     hic = hm.hiCMatrix()
     hic.nan_bins = []
     matrix = np.array([[1, 8, 5, 3, 0],
@@ -139,8 +139,8 @@ def test_convert_to_zscore_matrix_2():
 
 def test_save_load_cooler_format():
     outfile = '/tmp/matrix2.cool'
-    cut_intervals = [(b'a', 0, 10, 1), (b'a', 10, 20, 1),
-                     (b'a', 20, 30, 1), (b'a', 30, 40, 1), (b'b', 40, 50, 1)]
+    cut_intervals = [('a', 0, 10, 1), ('a', 10, 20, 1),
+                     ('a', 20, 30, 1), ('a', 30, 40, 1), ('b', 40, 50, 1)]
     hic = hm.hiCMatrix()
     hic.nan_bins = []
     matrix = np.array([[1, 8, 5, 3, 0],

--- a/hicexplorer/utilities.py
+++ b/hicexplorer/utilities.py
@@ -250,6 +250,8 @@ def toString(s):
         return s.decode('ascii')
     if isinstance(s, list):
         return [toString(x) for x in s]
+    if isinstance(s, np.ndarray):
+        return s.astype(str)
     return s
 
 


### PR DESCRIPTION
* [x] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [] Local tests pass (`py.test hicexplorer --doctest-modules`)

When loading a .h5 five in python3, the chromosome names are not converted to strings. 

The problem is caused because the function `toString` either works over bytes string or list but sometimes numpy arrays are used as in this line:

https://github.com/deeptools/HiCExplorer/blob/master/hicexplorer/HiCMatrix.py#L246

Unfortunately, the simple solution to modify `toString` to also work on numpy arrays breaks some of the tests.