### PR TITLE
Remove references to obsolete hicExport

### DIFF
--- a/bin/hicExport
+++ b/bin/hicExport
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-from hicexplorer.hicExport import main
-
-if __name__ == "__main__":
-    main()

--- a/docs/content/example_usage.rst
+++ b/docs/content/example_usage.rst
@@ -9,7 +9,6 @@ Example usage
    :maxdepth: 1
 
    mES-HiC_analysis
-   HiCExport
 
 How we use HiCExplorer
 ----------------------

--- a/hicexplorer/hicBuildMatrix.py
+++ b/hicexplorer/hicBuildMatrix.py
@@ -964,8 +964,7 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
                     # the restriction site are identified
                     frag_start = min(mate1.pos, mate2.pos) + \
                         len(pRestrictionSequence)
-                    frag_end = max(mate1.pos + mate1.qlen, mate2.pos +
-                                   mate2.qlen) - len(pRestrictionSequence)
+                    frag_end = max(mate1.pos + mate1.qlen, mate2.pos + mate2.qlen) - len(pRestrictionSequence)
                     mate_ref = pRefId2name[mate1.rname]
                     has_rf = sorted(
                         pRfPositions[mate_ref][frag_start: frag_end])
@@ -1014,8 +1013,7 @@ def process_data(pMateBuffer1, pMateBuffer2, pMinMappingQuality,
             # fill in coverage vector
             vec_start = int(max(0, mate.pos - mate_bin.begin) / pBinsize)
             length_coverage = pCoverageIndex[mate_bin_id].end - pCoverageIndex[mate_bin_id].begin
-            vec_end = min(length_coverage, int(vec_start +
-                                               len(mate.seq) / pBinsize))
+            vec_end = min(length_coverage, int(vec_start + len(mate.seq) / pBinsize))
             coverage_index = pCoverageIndex[mate_bin_id].begin + vec_start
             coverage_end = pCoverageIndex[mate_bin_id].begin + vec_end
             for i in xrange(coverage_index, coverage_end, 1):

--- a/hicexplorer/hicCompareMatrices.py
+++ b/hicexplorer/hicCompareMatrices.py
@@ -61,7 +61,7 @@ def main(args=None):
              "the same parameters. Check the matrix values using the tool `hicInfo`.")
 
     if hic1.chrBinBoundaries != hic2.chrBinBoundaries:
-        exit("The two matrices have different chromosome order. Use the tool `hicConvertFormat` to change the order.\n"
+        exit("The two matrices have different chromosome order. Use the tool `hicAdjustMatrix` to change the order.\n"
              "{}: {}\n"
              "{}: {}".format(args.matrices[0], hic1.chrBinBoundaries.keys(),
                              args.matrices[1], hic2.chrBinBoundaries.keys()))

--- a/hicexplorer/hicCompareMatrices.py
+++ b/hicexplorer/hicCompareMatrices.py
@@ -61,7 +61,7 @@ def main(args=None):
              "the same parameters. Check the matrix values using the tool `hicInfo`.")
 
     if hic1.chrBinBoundaries != hic2.chrBinBoundaries:
-        exit("The two matrices have different chromosome order. Use the tool `hicExport` to change the order.\n"
+        exit("The two matrices have different chromosome order. Use the tool `hicConvertFormat` to change the order.\n"
              "{}: {}\n"
              "{}: {}".format(args.matrices[0], hic1.chrBinBoundaries.keys(),
                              args.matrices[1], hic2.chrBinBoundaries.keys()))

--- a/hicexplorer/hicCorrectMatrix.py
+++ b/hicexplorer/hicCorrectMatrix.py
@@ -271,12 +271,12 @@ def fill_gaps(hic_ma, failed_bins, fill_contiguous=False):
             # the new row value is the mean between the upper
             # and lower rows
             fill_ma[missing_bin, 1:mat_size - 1] = \
-                (hic_ma.matrix[missing_bin - 1, :mat_size - 2] +
+                (hic_ma.matrix[missing_bin - 1, :mat_size - 2] +  # noqa: W504
                  hic_ma.matrix[missing_bin + 1, 2:]) / 2
 
             # same for cols
             fill_ma[1:mat_size - 1, missing_bin] = \
-                (hic_ma.matrix[:mat_size - 2, missing_bin - 1] +
+                (hic_ma.matrix[:mat_size - 2, missing_bin - 1] +  # noqa: W504
                  hic_ma.matrix[2:, missing_bin + 1]) / 2
 
     # identify the intersection points of the failed regions because they
@@ -428,7 +428,7 @@ def plot_total_contact_dist(hic_ma, args):
         ax2.set_xlim(mad_values.value_to_mad(np.array(ax1.get_xlim())))
 
         # get first local mininum value
-        local_min = [x for x, y in enumerate(dist) if 1 <= x < len(dist) - 1 and
+        local_min = [x for x, y in enumerate(dist) if 1 <= x < len(dist) - 1 and  # noqa: W504
                      dist[x - 1] > y < dist[x + 1]]
 
         if len(local_min) > 0:

--- a/hicexplorer/hicFindEnrichedContacts.py
+++ b/hicexplorer/hicFindEnrichedContacts.py
@@ -205,7 +205,7 @@ def transformMatrix(hicma, method, per_chr=False, original_matrix=None, depth_in
                     if dist_list[idx] == -1:
                         continue
                     elif (orig_ma[triu_ma.row[idx],
-                                  triu_ma.col[idx]] <=
+                                  triu_ma.col[idx]] <=  # noqa: W504
                           noise_level[chrom_list[idx]]):
                         under_noise += 1
                         continue
@@ -274,8 +274,7 @@ def transformMatrix(hicma, method, per_chr=False, original_matrix=None, depth_in
 
             if idx > 0 and (idx == 10000 or idx % 500000 == 0):
                 endtime = time.time()
-                estimated = (float(len(transf_ma) - idx) *
-                             (endtime - start_time)) / idx
+                estimated = (float(len(transf_ma) - idx) * (endtime - start_time)) / idx
                 mmin, sec = divmod(estimated, 60)
                 hour, mmin = divmod(mmin, 60)
                 log.debug("iteration: {} Estimated remaining time "
@@ -489,7 +488,7 @@ def fitNegBinom_Rserve(countsByDistance, plot_distribution=False,
         else:
             good += 1
 
-        if (plot_distribution and
+        if (plot_distribution and  # noqa: W504
                 dist in [50000] + range(0, max(list(countsByDistance)), 1000000)):
             # actual and fitted distributions are plotted
             # next to each other
@@ -678,7 +677,7 @@ def fitDistribution(countsByDistance, distribution, plot_distribution=False):
                                                          pval[distnc],
                                                          pval_nb))
 
-        if (plot_distribution and
+        if (plot_distribution and  # noqa: W504
                 distnc in range(50000, max(countsByDistance.keys()), 500000)):
 
             import matplotlib.pyplot as plt
@@ -796,7 +795,7 @@ def fit_nbinom(k):
     from scipy.special import psi
     from scipy.optimize import brentq
     N = len(k)
-    n = brentq(lambda r: sum(psi(k + r)) - N * psi(r) +
+    n = brentq(lambda r: sum(psi(k + r)) - N * psi(r) +  # noqa: W504
                N * np.log(r / (r + sum(k / N))),
                np.finfo(np.float128).eps,
                np.max(k))

--- a/hicexplorer/hicMergeMatrixBins.py
+++ b/hicexplorer/hicMergeMatrixBins.py
@@ -168,8 +168,7 @@ def running_window_merge(hic_matrix, num_bins):
     # remove illegal matrix id
     # that are less than zero
     # or bigger than matrix size
-    keep = ((new_row > -1) & (new_col > -1) &
-            (new_row < M) & (new_col < M))
+    keep = ((new_row > -1) & (new_col > -1) & (new_row < M) & (new_col < M))
     new_data = new_data[keep]
     new_row = new_row[keep]
     new_col = new_col[keep]

--- a/hicexplorer/hicPlotDistVsCounts.py
+++ b/hicexplorer/hicPlotDistVsCounts.py
@@ -290,7 +290,7 @@ def compute_distance_mean(hicmat, maxdepth=None, perchr=False):
 
         if maxdepth is None:
             maxdepth = np.inf
-        mean_dict[chrname] = OrderedDict([((k - 1) * binsize, v) for k, v in iteritems(mu) if k > 0 and
+        mean_dict[chrname] = OrderedDict([((k - 1) * binsize, v) for k, v in iteritems(mu) if k > 0 and  # noqa: W504
                                           (k - 1) * binsize <= maxdepth])
         # mean_dict[chrname]['intra_chr'] = mu[0]
 

--- a/hicexplorer/hicPlotMatrix.py
+++ b/hicexplorer/hicPlotMatrix.py
@@ -403,12 +403,12 @@ def getRegion(args, ma):
     args.region = [chrom, region_start, region_end]
     is_cooler = check_cooler(args.matrix)
     if is_cooler:
-        idx1, start_pos1 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom and
-                                 ((x[1] >= region_start and x[2] < region_end) or
-                                  (x[1] < region_end and x[2] < region_end and x[2] > region_start) or
+        idx1, start_pos1 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom and  # noqa: W504
+                                 ((x[1] >= region_start and x[2] < region_end) or                            # noqa: W504
+                                  (x[1] < region_end and x[2] < region_end and x[2] > region_start) or       # noqa: W504
                                   (x[1] > region_start and x[1] < region_end))])
     else:
-        idx1, start_pos1 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom and
+        idx1, start_pos1 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom and  # noqa: W504
                                  x[1] >= region_start and x[2] < region_end])
     if args.region2:
         chrom2, region_start2, region_end2 = translate_region(args.region2)
@@ -425,12 +425,12 @@ def getRegion(args, ma):
             if chrom2 not in list(ma.interval_trees):
                 exit("Chromosome name {} in --region2 not in matrix".format(change_chrom_names(chrom2)))
         if is_cooler:
-            idx2, start_pos2 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom2 and
-                                     ((x[1] >= region_start2 and x[2] < region_end2) or
-                                      (x[1] < region_end2 and x[2] < region_end2 and x[2] > region_start2) or
+            idx2, start_pos2 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom2 and  # noqa: W504
+                                     ((x[1] >= region_start2 and x[2] < region_end2) or                           # noqa: W504
+                                      (x[1] < region_end2 and x[2] < region_end2 and x[2] > region_start2) or     # noqa: W504
                                       (x[1] > region_start2 and x[1] < region_end2))])
         else:
-            idx2, start_pos2 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom2 and
+            idx2, start_pos2 = zip(*[(idx, x[1]) for idx, x in enumerate(ma.cut_intervals) if x[0] == chrom2 and  # noqa: W504
                                      x[1] >= region_start2 and x[2] < region_end2])
     else:
         idx2 = idx1

--- a/hicexplorer/hicPrepareQCreport.py
+++ b/hicexplorer/hicPrepareQCreport.py
@@ -267,8 +267,7 @@ def main(args=None):
 
     if 'Pairs mappable, unique and high quality' not in table.columns:
         table['Pairs mappable, unique and high quality'] = \
-            table['Pairs considered'] - (table['One mate unmapped'] + table['One mate not unique'] +
-                                         table['One mate low quality'])
+            table['Pairs considered'] - (table['One mate unmapped'] + table['One mate not unique'] + table['One mate low quality'])
 
     if 'same fragment (800 bp)' in table.columns:
         # older versions of the QC used the label 'same fragment (800 bp)'

--- a/hicexplorer/hicSumMatrices.py
+++ b/hicexplorer/hicSumMatrices.py
@@ -51,7 +51,7 @@ def main(args=None):
     for matrix in args.matrices[1:]:
         hic_to_append = hm.hiCMatrix(matrix)
         if hic.chrBinBoundaries != hic_to_append.chrBinBoundaries:
-            log.error("The two matrices have different chromosome order. Use the tool `hicExport` to change the order.\n"
+            log.error("The two matrices have different chromosome order. Use the tool `hicConvertFormat` to change the order.\n"
                       "{}: {}\n"
                       "{}: {}".format(args.matrices[0], list(hic.chrBinBoundaries),
                                       matrix, list(hic_to_append.chrBinBoundaries)))

--- a/hicexplorer/test/long_run/test_hicBuildMatrix_trivial_runs_2.py
+++ b/hicexplorer/test/long_run/test_hicBuildMatrix_trivial_runs_2.py
@@ -14,7 +14,6 @@ import os
 import shutil
 from psutil import virtual_memory
 
-from hicexplorer.utilities import genomicRegion
 from hicexplorer import hicBuildMatrix as hicBuildMatrix
 
 mem = virtual_memory()

--- a/hicexplorer/test/long_run/test_hicConvertFormat_trivial_runs.py
+++ b/hicexplorer/test/long_run/test_hicConvertFormat_trivial_runs.py
@@ -7,7 +7,6 @@ from hicexplorer import hicConvertFormat
 import pytest
 from hicmatrix import HiCMatrix as hm
 import numpy.testing as nt
-import numpy as np
 
 REMOVE_OUTPUT = True
 # DIFF = 60

--- a/hicexplorer/test/long_run/test_hicConvertFormat_trivial_runs_cool.py
+++ b/hicexplorer/test/long_run/test_hicConvertFormat_trivial_runs_cool.py
@@ -5,9 +5,6 @@ import os.path
 from tempfile import NamedTemporaryFile
 from hicexplorer import hicConvertFormat
 import pytest
-from hicmatrix import HiCMatrix as hm
-import numpy.testing as nt
-import numpy as np
 
 REMOVE_OUTPUT = True
 # DIFF = 60

--- a/scripts/hicComputeSaturation.py
+++ b/scripts/hicComputeSaturation.py
@@ -100,8 +100,7 @@ def main(args=None):
         print("\n Sampling {}% of data \n".format(i))
         # subsample
         ma = copy.deepcopy(hic_matrix)
-        ma.matrix.data = ((hic_matrix.matrix.data) *
-                          (float(i) / 100)).astype(int)
+        ma.matrix.data = ((hic_matrix.matrix.data) * (float(i) / 100)).astype(int)
         ma.matrix.eliminate_zeros()
 
         # remove outliers

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
     scripts=['bin/findRestSite', 'bin/hicAggregateContacts', 'bin/hicBuildMatrix', 'bin/hicCorrectMatrix',
              'bin/hicCorrelate', 'bin/hicFindEnrichedContacts', 'bin/hicFindTADs',
              'bin/hicMergeMatrixBins', 'bin/hicPlotMatrix', 'bin/hicPlotDistVsCounts',
-             'bin/hicPlotTADs', 'bin/hicSumMatrices', 'bin/hicExport', 'bin/hicInfo', 'bin/hicexplorer',
+             'bin/hicPlotTADs', 'bin/hicSumMatrices', 'bin/hicInfo', 'bin/hicexplorer',
              'bin/hicQC', 'bin/hicCompareMatrices', 'bin/hicPCA', 'bin/hicTransform', 'bin/hicPlotViewpoint',
              'bin/hicConvertFormat', 'bin/hicAdjustMatrix', 'bin/hicNormalize',
              'bin/hicAverageRegions', 'bin/hicPlotAverageRegions'


### PR DESCRIPTION
* [x] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

Remove references to obsolete HicExport + fix/surpress flake8 warnings. 
