### PR TITLE
Adding missing type to argparse arguments

### DIFF
--- a/hicexplorer/hicCompartmentsPolarization.py
+++ b/hicexplorer/hicCompartmentsPolarization.py
@@ -50,11 +50,13 @@ def parse_arguments():
 
     parserOpt.add_argument('--quantile', '-q',
                            help='number of quantiles',
-                           default=30)
+                           default=30,
+                           type=int)
 
     parserOpt.add_argument('--outliers',
                            help='precentage of outlier to remove',
-                           default=0)
+                           default=0,
+                           type=float)
 
     parserOpt.add_argument('--outputMatrix',
                            help='output .npz file includes all the generated matrices',

--- a/hicexplorer/test/general/test_hicCompartmentsPolarization.py
+++ b/hicexplorer/test/general/test_hicCompartmentsPolarization.py
@@ -14,9 +14,9 @@ def test_compartments_polarization():
     outfile = NamedTemporaryFile(suffix='.png', delete=False)
     outfile.close()
 
-    args = " -m {} --pca {} -o {} ".format(ROOT + "hicPCA/obsexp_norm.h5",
-                                           ROOT + "hicCompartmentsPolarization/pca1.bedgraph",
-                                           outfile.name).split()
+    args = " -m {} --pca {} -o {} --outliers 0.0 --quantile 30".format(ROOT + "hicPCA/obsexp_norm.h5",
+                                                                       ROOT + "hicCompartmentsPolarization/pca1.bedgraph",
+                                                                       outfile.name).split()
     hicCompartmentsPolarization.main(args)
     test = ROOT + "hicCompartmentsPolarization/compartmentsPolarizationRatio.png"
     res = compare_images(test, outfile.name, tolerance)


### PR DESCRIPTION
* [ ] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

