### PR TITLE
Viewpoint plots fix

### DIFF
--- a/docs/content/News.rst
+++ b/docs/content/News.rst
@@ -1,6 +1,14 @@
 News and Developments
 =====================
 
+Release 3.3.1
+-------------
+**15 November 2019**
+
+- Fixing a bug in the labeling of chicPlotViewpoints if the value range is counted in MB
+- Add an option to chicViewpoint to pre-compute a x-fold of p-value over the maximum value of the relative distance
+
+
 Release 3.3
 -----------
 **8 October 2019**

--- a/hicexplorer/_version.py
+++ b/hicexplorer/_version.py
@@ -2,4 +2,4 @@
 # This file is originally generated from Git information by running 'setup.py
 # version'. Distribution tarballs contain a pre-generated copy of this file.
 
-__version__ = '3.3.1-dev'
+__version__ = '3.3.1'

--- a/hicexplorer/_version.py
+++ b/hicexplorer/_version.py
@@ -2,4 +2,4 @@
 # This file is originally generated from Git information by running 'setup.py
 # version'. Distribution tarballs contain a pre-generated copy of this file.
 
-__version__ = '3.3'
+__version__ = '3.3.1-dev'

--- a/hicexplorer/chicPlotViewpoint.py
+++ b/hicexplorer/chicPlotViewpoint.py
@@ -376,7 +376,6 @@ def main(args=None):
                     for i in range(0, args.plotSampleNumber):
                         file_ = significantRegionsFile.readline().strip()
                         if file_ != '':
-
                             lines.append(file_)
                     if len(lines) > 0:
                         highlightSignificantRegionsFileList.append(lines)

--- a/hicexplorer/chicPlotViewpoint.py
+++ b/hicexplorer/chicPlotViewpoint.py
@@ -247,7 +247,7 @@ def plot_images(pInteractionFileList, pHighlightDifferentialRegionsFileList, pBa
             ticks = []
             x_labels = []
 
-            if pArgs.range[0] + pArgs.range[1] < 1e6:
+            if pArgs.range[0] + pArgs.range[1] <= 2e6:
                 divisor_legend = 1e3
                 mod_legend = 2e5
 
@@ -262,9 +262,9 @@ def plot_images(pInteractionFileList, pHighlightDifferentialRegionsFileList, pBa
                 log.debug('divisor_legend {}'.format(divisor_legend))
 
                 unit = 'kb'
-            elif pArgs.range[0] + pArgs.range[1] >= 1e6:
-                divisor_legend = 1e4
-                mod_legend = 2e6
+            elif pArgs.range[0] + pArgs.range[1] > 2e6:
+                divisor_legend = 1e6
+                mod_legend = 1e6
                 unit = 'Mb'
 
             for k, j in zip(range((pArgs.range[0])), range(pArgs.range[0], 1, -1)):
@@ -279,61 +279,6 @@ def plot_images(pInteractionFileList, pHighlightDifferentialRegionsFileList, pBa
                 if j % mod_legend == 0:
                     x_labels.append(str(-int(j) // int(divisor_legend)) + unit)
                     ticks.append(referencepoint_index + (k // pArgs.binResolution))
-            # if pArgs.range[0]  < 1e6:
-            #     upstream_divisor = 1e3
-            #     upstream_mod = 2e5
-
-            #     if pArgs.range[0] <= 1e4:
-            #         upstream_mod = 5e3
-            #     elif pArgs.range[0] <= 5e4:
-            #         upstream_mod = 1e4
-            #     elif pArgs.range[0] <= 1e5:
-            #         upstream_mod = 5e4
-
-            #     log.debug('upstream_divisor {}'.format(upstream_divisor))
-
-            #     upstream_unit = 'kb'
-            # elif pArgs.range[0] >= 1e6:
-            #     upstream_divisor = 1e4
-            #     upstream_mod = 2e6
-            #     upstream_unit = 'Mb'
-
-            # for k, j in zip(range((pArgs.range[0])), range(pArgs.range[0], 1, -1)):
-            #     if j % upstream_mod == 0:
-            #         x_labels.append(str(-int(j) // int(upstream_divisor)) + upstream_unit)
-            #         ticks.append(k // pArgs.binResolution)
-            # x_labels.append('RP')
-            # ticks.append(pArgs.range[0] // pArgs.binResolution)
-
-            # if pArgs.range[1] < 1e6:
-            #     downstream_divisor = 1e3
-            #     downstream_mod = 2e5
-
-            #     if pArgs.range[1] <= 1e4:
-            #         downstream_mod = 5e3
-            #     elif pArgs.range[1] <= 5e4:
-            #         downstream_mod = 1e4
-            #     elif pArgs.range[1] <= 1e5:
-            #         downstream_mod = 5e4
-
-            #     downstream_unit = 'kb'
-            # elif pArgs.range[1] >= 1e6:
-            #     downstream_divisor = 1e4
-            #     downstream_mod = 2e6
-            #     downstream_unit = 'Mb'
-            # downstream_divisor = 1e3 if pArgs.range[1] < 1e6 else 1e4
-            # downstream_mod = 2e5 if pArgs.range[1] < 1e6 else 2e6
-            # downstream_unit = 'kb' if pArgs.range[1] < 1e6 else 'Mb'
-            # referencepoint_index = ticks[-1]
-            # for k, j in zip(range(pArgs.range[1]), range(1, pArgs.range[1] + 1, 1)):
-            #     if j % downstream_mod == 0:
-            #         x_labels.append(str(-int(j) // int(downstream_divisor)) + downstream_unit)
-            #         ticks.append(referencepoint_index + (k // pArgs.binResolution))
-
-            # log.debug('ticks {}'.format(ticks))
-            # log.debug('x_labels {}'.format(x_labels))
-            # log.debug('data {}'.format(data))
-            # log.debug('data {}'.format(len(data)))
 
             ax1.set_ylabel('Number of interactions')
             ax1.set_xticks(ticks)

--- a/hicexplorer/chicViewpoint.py
+++ b/hicexplorer/chicViewpoint.py
@@ -77,6 +77,12 @@ $ chicViewpoint --matrices matrix1.cool matrix2.cool matrix3.cool --referencePoi
                            default=500000,
                            type=int
                            )
+    parserOpt.add_argument('--xFoldMaxValueNB', '-xfnb',
+                           help='x-fold factor to increase the number of precomputed p-values per relative genomic distance. If set to 1, the maximal distance is used. ',
+                           required=False,
+                           default=1,
+                           type=int
+                           )
     parserOpt.add_argument('--allViewpointsList', '-avl',
                            help='Writes a file where all viewpoints all samples are sorted by the viewpoints.',
                            required=False,
@@ -227,7 +233,7 @@ def main(args=None):
     background_model_mean_values = viewpointObj.readBackgroundDataFile(
         args.backgroundModelFile, args.range, pMean=True)
     background_sum_of_densities_dict = viewpointObj.computeSumOfDensities(
-        background_model, args)
+        background_model, args, pXfoldMaxValue=args.xFoldMaxValueNB)
 
     if not os.path.exists(args.outputFolder):
         try:


### PR DESCRIPTION
* [ ] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

- Bug fix labels chicPlotViewpoint concerning the MB value range
- Add option to chicViewpoint to pre-compute an x-fold of value for the p-values per relative distance