### PR TITLE
Initialize fail_flag and fail_message even if single_core

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,17 @@
-.. image:: https://travis-ci.org/deeptools/HiCExplorer.svg?branch=master
+|travis| |rtd| |conda| |docker| |galaxy|
+
+.. |travis| image:: https://travis-ci.org/deeptools/HiCExplorer.svg?branch=master
    :target: https://travis-ci.org/deeptools/HiCExplorer
-.. image:: https://readthedocs.org/projects/hicexplorer/badge/?version=latest
+.. |rtd| image:: https://readthedocs.org/projects/hicexplorer/badge/?version=latest
    :target: http://hicexplorer.readthedocs.io/?badge=latest
-.. image:: https://anaconda.org/bioconda/hicexplorer/badges/installer/conda.svg
+.. |conda| image:: https://anaconda.org/bioconda/hicexplorer/badges/installer/conda.svg
    :target: https://anaconda.org/bioconda/hicexplorer
-.. image:: https://quay.io/repository/biocontainers/hicexplorer/status
+.. |galaxy| image:: https://img.shields.io/badge/usegalaxy-.eu-brightgreen?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAASCAYAAABB7B6eAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAACXBIWXMAAAsTAAALEwEAmpwYAAACC2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDx0aWZmOkNvbXByZXNzaW9uPjE8L3RpZmY6Q29tcHJlc3Npb24+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDx0aWZmOlBob3RvbWV0cmljSW50ZXJwcmV0YXRpb24+MjwvdGlmZjpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KD0UqkwAAAn9JREFUOBGlVEuLE0EQruqZiftwDz4QYT1IYM8eFkHFw/4HYX+GB3/B4l/YP+CP8OBNTwpCwFMQXAQPKtnsg5nJZpKdni6/6kzHvAYDFtRUT71f3UwAEbkLch9ogQxcBwRKMfAnM1/CBwgrbxkgPAYqlBOy1jfovlaPsEiWPROZmqmZKKzOYCJb/AbdYLso9/9B6GppBRqCrjSYYaquZq20EUKAzVpjo1FzWRDVrNay6C/HDxT92wXrAVCH3ASqq5VqEtv1WZ13Mdwf8LFyyKECNbgHHAObWhScf4Wnj9CbQpPzWYU3UFoX3qkhlG8AY2BTQt5/EA7qaEPQsgGLWied0A8VKrHAsCC1eJ6EFoUd1v6GoPOaRAtDPViUr/wPzkIFV9AaAZGtYB568VyJfijV+ZBzlVZJ3W7XHB2RESGe4opXIGzRTdjcAupOK09RA6kzr1NTrTj7V1ugM4VgPGWEw+e39CxO6JUw5XhhKihmaDacU2GiR0Ohcc4cZ+Kq3AjlEnEeRSazLs6/9b/kh4eTC+hngE3QQD7Yyclxsrf3cpxsPXn+cFdenF9aqlBXMXaDiEyfyfawBz2RqC/O9WF1ysacOpytlUSoqNrtfbS642+4D4CS9V3xb4u8P/ACI4O810efRu6KsC0QnjHJGaq4IOGUjWTo/YDZDB3xSIxcGyNlWcTucb4T3in/3IaueNrZyX0lGOrWndstOr+w21UlVFokILjJLFhPukbVY8OmwNQ3nZgNJNmKDccusSb4UIe+gtkI+9/bSLJDjqn763f5CQ5TLApmICkqwR0QnUPKZFIUnoozWcQuRbC0Km02knj0tPYx63furGs3x/iPnz83zJDVNtdP3QAAAABJRU5ErkJggg==
+   :target: https://usegalaxy.eu/root?tool_id=hicexplorer_hicplotviewpoint
+.. |docker| image:: https://quay.io/repository/biocontainers/hicexplorer/status
    :target: https://quay.io/repository/biocontainers/hicexplorer
+
+
 
 HiCExplorer
 ===========

--- a/hicexplorer/hicDetectLoops.py
+++ b/hicexplorer/hicDetectLoops.py
@@ -997,6 +997,8 @@ def main(args=None):
     else:
         single_core = False
 
+    fail_flag = False
+    fail_message = ''
     if single_core:
         for chromosome in chromosomes_list:
             if is_cooler:
@@ -1022,8 +1024,6 @@ def main(args=None):
         all_threads_done = False
         thread_done = [False] * args.threads
         count_call_of_read_input = 0
-        fail_flag = False
-        fail_message = ''
         while not all_data_processed or not all_threads_done:
             for i in range(args.threads):
                 if queue[i] is None and not all_data_processed:


### PR DESCRIPTION
If running on a single chromosome, these variables were not being set, resulting in the
error:

Traceback (most recent call last):
  File "/opt/anaconda2/envs/HiCExplorer/bin/hicDetectLoops", line 7, in <module>
    main()
  File "/opt/anaconda2/envs/HiCExplorer/lib/python3.6/site-packages/hicexplorer/hicDetectLoops.py", line 1072, in main
    if fail_flag:
UnboundLocalError: local variable 'fail_flag' referenced before assignment

* [ ] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

