### PR TITLE
Add line to save the polarization_ratio in a text file

### DIFF
--- a/hicexplorer/hicCompartmentalization.py
+++ b/hicexplorer/hicCompartmentalization.py
@@ -220,3 +220,4 @@ def main(args=None):
         np.savez(args.outputMatrix, [matrix for matrix in output_matrices])
     plot_polarization_ratio(
         polarization_ratio, args.outputFileName, labels, args.quantile)
+    np.savetxt(args.outputFileName+'_'+'dat',polarization_ratio)


### PR DESCRIPTION
Saving the polarization_ratio in a text file

* [ ] Flake8 passes (`flake8 . --exclude=.venv,.build,planemo_test_env,build --ignore=E501,F403,E402,F999,F405,E712`)
* [ ] Local tests pass (`py.test hicexplorer --doctest-modules`)

